### PR TITLE
Add channel token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ To deploy this storefront in a production environment, take the following steps:
      }
    })
    ```
+6. Optionally set a `CHANNEL_TOKEN` environment variable before running the build to specify which Vendure channel this storefront should use. On Railway deployments this can be configured in the project settings under **Variables**.
 
 ### Deploying the demo
 

--- a/src/app/core/apollo-client-provider.ts
+++ b/src/app/core/apollo-client-provider.ts
@@ -122,14 +122,17 @@ export function apolloOptionsFactory(
         });
     });
     const middleware = new ApolloLink((operation, forward) => {
-        if (isPlatformBrowser(platformId)) {
-            operation.setContext({
-                headers: new HttpHeaders().set(
-                    'Authorization',
-                    `Bearer ${localStorage.getItem(AUTH_TOKEN_KEY) || null}`,
-                ),
-            });
+        let headers = new HttpHeaders();
+        if (environment.channelToken) {
+            headers = headers.set('vendure-channel-token', environment.channelToken);
         }
+        if (isPlatformBrowser(platformId)) {
+            headers = headers.set(
+                'Authorization',
+                `Bearer ${localStorage.getItem(AUTH_TOKEN_KEY) || null}`,
+            );
+        }
+        operation.setContext({ headers });
         return forward(operation);
     });
 

--- a/src/environments/environment.docker.ts
+++ b/src/environments/environment.docker.ts
@@ -5,4 +5,5 @@ export const environment = {
     shopApiPath: 'shop-api',
     baseHref: '/',
     tokenMethod: 'bearer',
+    channelToken: (typeof process !== 'undefined' && (process as any).env && (process as any).env.CHANNEL_TOKEN) || '',
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -5,4 +5,5 @@ export const environment = {
     shopApiPath: 'shop-api',
     baseHref: '/',
     tokenMethod: 'cookie',
+    channelToken: (typeof process !== 'undefined' && (process as any).env && (process as any).env.CHANNEL_TOKEN) || '',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -9,6 +9,7 @@ export const environment = {
     shopApiPath: 'shop-api',
     baseHref: '/',
     tokenMethod: 'bearer',
+    channelToken: (typeof process !== 'undefined' && (process as any).env && (process as any).env.CHANNEL_TOKEN) || '',
 };
 
 /*


### PR DESCRIPTION
## Summary
- support reading optional `CHANNEL_TOKEN` from build environment
- send channel token header in Apollo client
- document `CHANNEL_TOKEN` for Railway usage

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682fcaf3148321b9ad440631c448de